### PR TITLE
AACExtractor: check bounds during seek

### DIFF
--- a/media/libstagefright/AACExtractor.cpp
+++ b/media/libstagefright/AACExtractor.cpp
@@ -295,6 +295,10 @@ status_t AACSource::read(
     if (options && options->getSeekTo(&seekTimeUs, &mode)) {
         if (mFrameDurationUs > 0) {
             int64_t seekFrame = seekTimeUs / mFrameDurationUs;
+            if (seekFrame < 0 || seekFrame >= (int64_t)mOffsetVector.size()) {
+                android_errorWriteLog(0x534e4554, "70239507");
+                return ERROR_MALFORMED;
+            }
             mCurrentTimeUs = seekFrame * mFrameDurationUs;
 
             mOffset = mOffsetVector.itemAt(seekFrame);


### PR DESCRIPTION
Bug: 70239507
Test: stagefright -a poc.aac
Change-Id: I61225a04c76fe8855bd2591fb14b734099fa3be6
(cherry picked from commit 0790581021d89ae1d7242e5eb1197bfd12725c85)